### PR TITLE
Google Docs template for web service specification documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This should be updated fairly regularly. As usual, **pull requests are encourage
 * [Laravel](http://laravel.com/docs) - Easily-readable and well-organized docs. Navigation is well formatted and articles are easy to consume. (contributed by [@ToddSmithSalter](https://github.com/toddsmithsalter))
 * [FullCalendar](http://arshaw.com/fullcalendar/docs/) – Concise overview of all APIs on a single page, and in-depth descriptions for each. (contributed by [@gr2m](https://github.com/gr2m/))
 * [Rust Guides](http://doc.rust-lang.org/guide.html) - Rust is a pre-1.0 language with a constantly-changing API, but the docs (written by [Steve Klabnik](https://github.com/steveklabnik)) are clearly a high priority. The guides in particular illustrate core concepts of the standard library in a conversational, accessible style. (contributed by [Nick Cox](https://github.com/thenickcox)
+* [A Google Docs template for web service documentation](https://docs.google.com/document/d/1HSQ3Fe77hnthw8hizqvXJU-qGEPHavMkctvCCadkVbY/edit) – A clean and elegant Google Docs template for web service specification documentation
 
 ### Writing about Docs (again, in no particular order)
 


### PR DESCRIPTION
Adding a Google Docs template for web service specification documentation