### PR TITLE
Update Qt link (issue #96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This should be updated fairly regularly. As usual, **pull requests are encourage
 * [Pyramid Documentation](http://docs.pylonsproject.org/en/latest/docs/pyramid.html) (contributed by [csenger](https://github.com/csenger))
 * [Number Laundry API](http://numberlaundry.whatcheer.com/) - Fun design, simple examples. (contributed by [@jmhobbs](https://twitter.com/jmhobbs))
 * [Backbone.js](http://documentcloud.github.com/backbone/) and [Underscore.js](http://underscorejs.org) - Simple, clean, single page. (contributed by [@twe4ked](http://twitter.com/twe4ked))
-* [Qt](http://developer.qt.nokia.com/doc/qt-4.8/) - Very comprehensive documentation with tutorials and guides and great examples. (contributed by [@nikhilcutshort](https://twitter.com/nikhilcutshort))
+* [Qt](http://doc.qt.io/) - Very comprehensive documentation with tutorials and guides and great examples. (contributed by [@nikhilcutshort](https://twitter.com/nikhilcutshort))
 * [CasperJS](http://casperjs.org) - CasperJS is a navigation scripting & testing utility for PhantomJS, written in Javascript. (contributed by [@n1k0](https://twitter.com/n1k0))
 * [Leaflet](http://leaflet.cloudmade.com/reference.html) - Simple and elegant single page docs. (contributed by [@mourner](http://github.com/mourner))
 * [rubyamqp.info](http://rubyamqp.info) - A number of in-depth guides that cover Ruby amqp gem but also try to explain AMQP 0.9.1 features, why they exist and how they are supposed to be used. (contributed by [Michael Klishin](https://twitter.com/#!/michaelklishin/))


### PR DESCRIPTION
The previous Qt 4.8 link is now dead.  This change updates the Qt link
to go to the new home of Qt's documentation (http://doc.qt.io/).